### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ One class can only handle one queue. so if you want to enroll dead letter queue,
 SqsService needs to be injected to produce the message.
 
 ```ts
+@Injectable()
 export class AppService {
   public constructor(
     private readonly sqsService: SqsService,


### PR DESCRIPTION
If you copy and paste the code, it doesn't work, the `sqsService` is `undefined` in the consumer Service
You need to decorate the Class to mark it as a entity (and therefore the sqsService can be injected)